### PR TITLE
Generic OAuth2 support [keycloak for example]

### DIFF
--- a/knowage-ce-parent/pom.xml
+++ b/knowage-ce-parent/pom.xml
@@ -93,6 +93,7 @@
 		<module>../spagobi-metamodel-utils</module>
 		<module>../knowagedao</module>
 		<module>../knowage-core</module>
+		<module>../knowageoauth2</module>
 		<module>../knowageoauth2securityprovider</module>
 		<module>../knowageldapsecurityprovider</module>
 		<module>../knowagegooglesecurityprovider</module>

--- a/knowagedatabasescripts/.project
+++ b/knowagedatabasescripts/.project
@@ -10,8 +10,14 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
 </projectDescription>

--- a/knowageoauth2/pom.xml
+++ b/knowageoauth2/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>it.eng.knowage</groupId>
+		<artifactId>knowage-ce-parent</artifactId>
+		<version>7.4.0-SNAPSHOT</version>
+		<relativePath>../knowage-ce-parent/pom.xml</relativePath>
+	</parent>
+
+	<artifactId>knowageoauth2</artifactId>
+	<packaging>jar</packaging>
+
+	<dependencies>
+
+		<dependency>
+			<groupId>it.eng.knowage</groupId>
+			<artifactId>knowage-dao</artifactId>
+			<version>7.4.0-SNAPSHOT</version>
+			<scope>compile</scope>
+		</dependency>
+		
+		
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>javax.servlet-api</artifactId>
+			<version>3.0.1</version> <!-- WebLogic uses 3.1.0, Tomcat 7 uses 3.0 -->
+			<scope>provided</scope>
+		</dependency>
+		
+	</dependencies>
+	
+</project>

--- a/knowageoauth2/src/main/java/it/eng/knowage/security/oauth2/OAuth2Client.java
+++ b/knowageoauth2/src/main/java/it/eng/knowage/security/oauth2/OAuth2Client.java
@@ -53,14 +53,14 @@ public class OAuth2Client {
 	}
 
 	// It returns the access token of OAuth2 given the authorization code
-	public String getAccessToken(String code) {
+	public String getAccessTokenWithRedirect(String code, String redirectUrl) {
 		logger.debug("IN");
 		try {
 			logger.debug("using authorization code grant");
 			PostMethod httppost = createPostMethodForAccessToken();
 			httppost.setParameter("grant_type", "authorization_code");
 			httppost.setParameter("code", code);
-			httppost.setParameter("redirect_uri", config.getRedirectUrl());
+			httppost.setParameter("redirect_uri", redirectUrl);
 
 			return sendHttpPost(httppost);
 		} catch (Exception e) {
@@ -71,7 +71,7 @@ public class OAuth2Client {
 	}
 
 	// It returns the access token of OAuth2 given username and password
-	public String getAccessToken(String username, String password) {
+	public String getAccessTokenWithPassword(String username, String password) {
 		logger.debug("IN");
 		try {
 			logger.debug("using password grant");

--- a/knowageoauth2/src/main/java/it/eng/knowage/security/oauth2/OAuth2Client.java
+++ b/knowageoauth2/src/main/java/it/eng/knowage/security/oauth2/OAuth2Client.java
@@ -1,0 +1,128 @@
+/* SpagoBI, the Open Source Business Intelligence suite
+
+ * Copyright (C) 2012 Engineering Ingegneria Informatica S.p.A. - SpagoBI Competency Center
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0, without the "Incompatible With Secondary Licenses" notice.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package it.eng.knowage.security.oauth2;
+
+import java.io.IOException;
+import java.util.Base64;
+
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.HttpException;
+import org.apache.commons.httpclient.HttpState;
+import org.apache.commons.httpclient.UsernamePasswordCredentials;
+import org.apache.commons.httpclient.methods.PostMethod;
+import org.apache.log4j.LogMF;
+import org.apache.log4j.Logger;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import it.eng.spagobi.utilities.exceptions.SpagoBIRuntimeException;
+
+public class OAuth2Client {
+	private static Logger logger = Logger.getLogger(OAuth2Client.class);
+	private static OAuth2Config config;
+
+	public OAuth2Client() {
+		config = OAuth2Config.getInstance();
+	}
+
+	public HttpClient getHttpClient() {
+
+		String proxyUrl = System.getProperty("http.proxyHost");
+		String proxyPort = System.getProperty("http.proxyPort");
+		String proxyUser = System.getProperty("http.proxyUsername");
+		String proxyPassword = System.getProperty("http.proxyPassword");
+
+		HttpClient client = new HttpClient();
+		if (proxyUrl != null && proxyPort != null) {
+			logger.debug("Setting proxy configuration ...");
+			client.getHostConfiguration().setProxy(proxyUrl, Integer.parseInt(proxyPort));
+			if (proxyUser != null) {
+				logger.debug("Setting proxy authentication configuration ...");
+				HttpState state = new HttpState();
+				state.setProxyCredentials(null, null, new UsernamePasswordCredentials(proxyUser, proxyPassword));
+				client.setState(state);
+			}
+		} else {
+			logger.debug("No proxy configuration found");
+		}
+
+		return client;
+	}
+
+	// It returns the access token of OAuth2 given the authorization code
+	public String getAccessToken(String code) {
+		logger.debug("IN");
+		try {
+			logger.debug("using authorization code grant");
+			PostMethod httppost = createPostMethodForAccessToken();
+			httppost.setParameter("grant_type", "authorization_code");
+			httppost.setParameter("code", code);
+			httppost.setParameter("redirect_uri", config.getRedirectUrl());
+
+			return sendHttpPost(httppost);
+		} catch (Exception e) {
+			throw new SpagoBIRuntimeException("Error while trying to get access token from OAuth2 provider", e);
+		} finally {
+			logger.debug("OUT");
+		}
+	}
+
+	// It returns the access token of OAuth2 given username and password
+	public String getAccessToken(String username, String password) {
+		logger.debug("IN");
+		try {
+			logger.debug("using password grant");
+			PostMethod httppost = createPostMethodForAccessToken();
+			httppost.setParameter("grant_type", "password");
+			httppost.setParameter("username", username);
+			httppost.setParameter("password", password);
+			httppost.setParameter("client_id", config.getClientId());
+
+			return sendHttpPost(httppost);
+		} catch (Exception e) {
+			throw new SpagoBIRuntimeException("Error while trying to get access token from OAuth2 provider", e);
+		} finally {
+			logger.debug("OUT");
+		}
+	}
+
+	// The generated PostMethod object is used to retrieve access token (OAuth2)
+	private PostMethod createPostMethodForAccessToken() {
+		String authorizationCredentials = config.getClientId() + ":" + config.getClientSecret();
+		String encoded = Base64.getEncoder().encodeToString(authorizationCredentials.getBytes());
+		encoded = encoded.replaceAll("\n", "");
+		encoded = encoded.replaceAll("\r", "");
+
+		PostMethod httppost = new PostMethod(config.getTokenUrl());
+		httppost.setRequestHeader("Authorization", "Basic " + encoded);
+		httppost.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
+
+		return httppost;
+	}
+
+	// It sends the http request specified in PostMethod and returns the access
+	// token returned by server
+	private String sendHttpPost(PostMethod httppost) throws HttpException, IOException, JSONException {
+		HttpClient httpClient = getHttpClient();
+		int statusCode = httpClient.executeMethod(httppost);
+		byte[] response = httppost.getResponseBody();
+		if (statusCode != 200) {
+			logger.error("Error while getting access token from OAuth2 provider: server returned statusCode = "
+					+ statusCode);
+			LogMF.error(logger, "Server response is:\n{0}", new Object[] { new String(response) });
+			throw new SpagoBIRuntimeException(
+					"Error while getting access token from OAuth2 provider: server returned statusCode = "
+							+ statusCode);
+		}
+
+		String responseStr = new String(response);
+		LogMF.debug(logger, "Server response is:\n{0}", responseStr);
+		JSONObject jsonObject = new JSONObject(responseStr);
+		String accessToken = jsonObject.getString("access_token");
+
+		return accessToken;
+	}
+}

--- a/knowageoauth2/src/main/java/it/eng/knowage/security/oauth2/OAuth2Config.java
+++ b/knowageoauth2/src/main/java/it/eng/knowage/security/oauth2/OAuth2Config.java
@@ -1,0 +1,90 @@
+/* SpagoBI, the Open Source Business Intelligence suite
+
+ * Copyright (C) 2012 Engineering Ingegneria Informatica S.p.A. - SpagoBI Competency Center
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0, without the "Incompatible With Secondary Licenses" notice.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package it.eng.knowage.security.oauth2;
+
+import java.util.Objects;
+
+import org.apache.log4j.Logger;
+
+/**
+ * @author Jeremy Branham (jeremy@savantly.net)
+ *
+ */
+public class OAuth2Config {
+	static private Logger logger = Logger.getLogger(OAuth2Config.class);
+	private static OAuth2Config instance = null;
+	private final String authorizeUrl;
+	private final String redirectUrl;
+	private final String clientId;
+	private final String clientSecret;
+	private final String tokenUrl;
+	private final String userInfoUrl;
+	private final String adminEmail;
+	private final String scopes;
+	
+	public OAuth2Config() {
+		this.authorizeUrl = System.getProperty("oauth_authorize_url", System.getenv("OAUTH2_AUTHORIZE_URL"));
+		this.clientId = System.getProperty("oauth_client_id", System.getenv("OAUTH2_CLIENT_ID"));
+		this.clientSecret = System.getProperty("oauth_client_secret", System.getenv("OAUTH2_CLIENT_SECRET"));
+		this.redirectUrl = System.getProperty("oauth_redirect_url", System.getenv("OAUTH2_REDIRECT_URL"));
+		this.tokenUrl = System.getProperty("oauth_token_url", System.getenv("OAUTH2_TOKEN_URL"));
+		this.userInfoUrl = System.getProperty("oauth_user_info_url", System.getenv("OAUTH2_USER_INFO_URL"));
+		this.adminEmail = System.getProperty("oauth_admin_email", System.getenv("OAUTH2_ADMIN_EMAIL"));
+		
+		String _scopes = System.getProperty("oauth_scopes", System.getenv("OAUTH2_SCOPES"));
+		this.scopes = Objects.isNull(_scopes) ? "openid,profile" : _scopes;
+		
+		logger.debug("constructed OAuth2Config: " + this.toString());
+	}
+
+	public static OAuth2Config getInstance() {
+		if (instance == null) {
+			instance = new OAuth2Config();
+		}
+		return instance;
+	}
+
+	public String getAuthorizeUrl() {
+		return this.authorizeUrl;
+	}
+
+	public String getRedirectUrl() {
+		return this.redirectUrl;
+	}
+
+	public String getClientId() {
+		return this.clientId;
+	}
+
+	public String getClientSecret() {
+		return this.clientSecret;
+	}
+
+	public String getTokenUrl() {
+		return this.tokenUrl;
+	}
+	
+	public String getUserInfoUrl() {
+		return this.userInfoUrl;
+	}
+	
+	public String getScopes() {
+		return this.scopes;
+	}
+
+	public String getAdminEmail() {
+		return this.adminEmail;
+	}
+
+	@Override
+	public String toString() {
+		return "OAuth2Config [authorizeUrl=" + authorizeUrl + ", redirectUrl=" + redirectUrl + ", clientId=" + clientId
+				+ ", clientSecret=" + clientSecret + ", tokenUrl=" + tokenUrl + ", userInfoUrl=" + userInfoUrl
+				+ ", adminEmail=" + adminEmail + ", scopes=" + scopes + "]";
+	}
+	
+	
+}

--- a/knowageoauth2/src/main/java/it/eng/knowage/security/oauth2/OAuth2Config.java
+++ b/knowageoauth2/src/main/java/it/eng/knowage/security/oauth2/OAuth2Config.java
@@ -24,6 +24,8 @@ public class OAuth2Config {
 	private final String userInfoUrl;
 	private final String adminEmail;
 	private final String scopes;
+	private final String userIdClaim;
+	private final String userNameClaim;
 	
 	public OAuth2Config() {
 		this.authorizeUrl = System.getProperty("oauth_authorize_url", System.getenv("OAUTH2_AUTHORIZE_URL"));
@@ -35,7 +37,13 @@ public class OAuth2Config {
 		this.adminEmail = System.getProperty("oauth_admin_email", System.getenv("OAUTH2_ADMIN_EMAIL"));
 		
 		String _scopes = System.getProperty("oauth_scopes", System.getenv("OAUTH2_SCOPES"));
-		this.scopes = Objects.isNull(_scopes) ? "openid,profile" : _scopes;
+		this.scopes = Objects.isNull(_scopes) ? "openid profile" : _scopes;
+
+		String _userIdClaim = System.getProperty("oauth_user_id_claim", System.getenv("OAUTH2_USER_ID_CLAIM"));
+		this.userIdClaim = Objects.isNull(_userIdClaim) ? "sub" : _userIdClaim;
+
+		String _userNameClaim = System.getProperty("oauth_user_name_claim", System.getenv("OAUTH2_USER_NAME_CLAIM"));
+		this.userNameClaim = Objects.isNull(_userNameClaim) ? "preferred_username" : _userNameClaim;
 		
 		logger.debug("constructed OAuth2Config: " + this.toString());
 	}
@@ -79,12 +87,21 @@ public class OAuth2Config {
 		return this.adminEmail;
 	}
 
+	public String getUserIdClaim() {
+		return userIdClaim;
+	}
+
+	public String getUserNameClaim() {
+		return userNameClaim;
+	}
+
 	@Override
 	public String toString() {
 		return "OAuth2Config [authorizeUrl=" + authorizeUrl + ", redirectUrl=" + redirectUrl + ", clientId=" + clientId
 				+ ", clientSecret=" + clientSecret + ", tokenUrl=" + tokenUrl + ", userInfoUrl=" + userInfoUrl
-				+ ", adminEmail=" + adminEmail + ", scopes=" + scopes + "]";
+				+ ", adminEmail=" + adminEmail + ", scopes=" + scopes + ", userIdClaim=" + userIdClaim
+				+ ", userNameClaim=" + userNameClaim + "]";
 	}
 	
-	
+
 }

--- a/knowageoauth2/src/main/java/it/eng/knowage/security/oauth2/OAuth2Filter.java
+++ b/knowageoauth2/src/main/java/it/eng/knowage/security/oauth2/OAuth2Filter.java
@@ -89,7 +89,7 @@ public class OAuth2Filter implements Filter {
 				final String accessToken = client.getAccessTokenWithRedirect(code, oauth2RedirectUrl);
 				session.setAttribute("access_token", accessToken);
 
-				final String postAuthRedirectUrl = Optional.of(session.getAttribute("redirectUrl"))
+				final String postAuthRedirectUrl = Optional.ofNullable(session.getAttribute("redirectUrl"))
 						.orElse(oauth2RedirectUrl).toString();
 				logger.debug("redirecting to initially requested page: " + postAuthRedirectUrl);
 				((HttpServletResponse) response).sendRedirect(postAuthRedirectUrl);

--- a/knowageoauth2/src/main/java/it/eng/knowage/security/oauth2/OAuth2Filter.java
+++ b/knowageoauth2/src/main/java/it/eng/knowage/security/oauth2/OAuth2Filter.java
@@ -1,0 +1,100 @@
+/*
+ * Knowage, Open Source Business Intelligence suite
+ * Copyright (C) 2016 Engineering Ingegneria Informatica S.p.A.
+ *
+ * Knowage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Knowage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package it.eng.knowage.security.oauth2;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.util.UUID;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import org.apache.log4j.Logger;
+
+/**
+ * Servlet Filter implementation class OAuthFilter
+ *
+ * @author Alessandro Daniele (alessandro.daniele@eng.it)
+ * @author Jeremy Branham (jeremy@savantly.net)
+ */
+public class OAuth2Filter implements Filter {
+	static private Logger logger = Logger.getLogger(OAuth2Filter.class);
+
+	/**
+	 * @see Filter#destroy()
+	 */
+	@Override
+	public void destroy() {
+		// TODO Auto-generated method stub
+	}
+
+	/**
+	 * @see Filter#doFilter(ServletRequest, ServletResponse, FilterChain)
+	 */
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+		logger.debug("IN");
+
+		HttpSession session = ((HttpServletRequest) request).getSession();
+
+		OAuth2Config oauth2Config = OAuth2Config.getInstance();
+
+		if (session.isNew() || session.getAttribute("access_token") == null) {
+			if (((HttpServletRequest) request).getParameter("code") == null) {
+				// We have to retrieve the Oauth2's code redirecting the browser
+				// to the OAuth2 provider
+				String url = oauth2Config.getAuthorizeUrl();
+				url += "?response_type=code&client_id=" + oauth2Config.getClientId();
+				url += "&scope=" + OAuth2Config.getInstance().getScopes();
+				url += "&redirect_uri=" + URLEncoder.encode(oauth2Config.getRedirectUrl(), "UTF-8");
+				url += "&state=" + URLEncoder.encode(UUID.randomUUID().toString(), "UTF-8");
+				logger.debug("redirecting to login: " + url);
+				((HttpServletResponse) response).sendRedirect(url);
+			} else {
+				// Using the code we get the access token and put it in session
+				final OAuth2Client client = new OAuth2Client();
+				final String code = ((HttpServletRequest) request).getParameter("code");
+				logger.debug("using authorization code to fetch access token: " + code);
+				final String accessToken = client.getAccessToken(code);
+				session.setAttribute("access_token", accessToken);
+
+				chain.doFilter(request, response);
+			}
+		} else {
+			// pass the request along the filter chain
+			chain.doFilter(request, response);
+		}
+
+		logger.debug("OUT");
+	}
+
+	/**
+	 * @see Filter#init(FilterConfig)
+	 */
+	@Override
+	public void init(FilterConfig fConfig) throws ServletException {
+
+	}
+}

--- a/knowageoauth2/src/main/java/it/eng/knowage/security/oauth2/OAuth2SecurityInfoProvider.java
+++ b/knowageoauth2/src/main/java/it/eng/knowage/security/oauth2/OAuth2SecurityInfoProvider.java
@@ -59,6 +59,7 @@ public class OAuth2SecurityInfoProvider implements ISecurityInfoProvider {
 		List<String> attributes = new ArrayList<String>();
 		attributes.add("displayName");
 		attributes.add("email");
+		attributes.addAll(OAuth2Config.getInstance().getProfileAttributes());
 		return attributes;
 	}
 

--- a/knowageoauth2/src/main/java/it/eng/knowage/security/oauth2/OAuth2SecurityInfoProvider.java
+++ b/knowageoauth2/src/main/java/it/eng/knowage/security/oauth2/OAuth2SecurityInfoProvider.java
@@ -1,0 +1,65 @@
+/* SpagoBI, the Open Source Business Intelligence suite
+
+ * Copyright (C) 2012 Engineering Ingegneria Informatica S.p.A. - SpagoBI Competency Center
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0, without the "Incompatible With Secondary Licenses" notice.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package it.eng.knowage.security.oauth2;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.log4j.Logger;
+
+import it.eng.spagobi.commons.bo.Role;
+import it.eng.spagobi.commons.dao.DAOFactory;
+import it.eng.spagobi.commons.metadata.SbiTenant;
+import it.eng.spagobi.security.ISecurityInfoProvider;
+
+/**
+ * @author Jeremy Branham (jeremy@savantly.net)
+ *
+ */
+public class OAuth2SecurityInfoProvider implements ISecurityInfoProvider {
+
+	static private Logger logger = Logger.getLogger(OAuth2SecurityInfoProvider.class);
+
+	/**
+	 * TODO: Is there an oauth2 standard for getting all roles?
+	 */
+	@Override
+	public List getRoles() {
+		logger.debug("IN");
+
+		List<SbiTenant> tenants = DAOFactory.getTenantsDAO().loadAllTenants();
+
+		List<Role> roles = new ArrayList<Role>();
+		List<String> roleStringArray = new ArrayList<>();
+		roleStringArray.add("admin");
+		roleStringArray.add("dev");
+		roleStringArray.add("modeladmin");
+		roleStringArray.add("user");
+
+		for (String name : roleStringArray) {
+
+			for (SbiTenant tenant : tenants) {
+				Role role = new Role(name, name);
+				role.setOrganization(tenant.getName());
+				roles.add(role);
+			}
+		}
+		logger.debug("OUT");
+		return roles;
+	}
+
+	/**
+	 * TODO: should this be configurable?
+	 */
+	@Override
+	public List getAllProfileAttributesNames() {
+		List<String> attributes = new ArrayList<String>();
+		attributes.add("displayName");
+		attributes.add("email");
+		return attributes;
+	}
+
+}

--- a/knowageoauth2/src/main/java/it/eng/knowage/security/oauth2/OAuth2SecurityServiceSupplier.java
+++ b/knowageoauth2/src/main/java/it/eng/knowage/security/oauth2/OAuth2SecurityServiceSupplier.java
@@ -112,6 +112,12 @@ public class OAuth2SecurityServiceSupplier implements ISecurityServiceSupplier {
 			attributes.put("userId", userId);
 			attributes.put("userName", userName);
 			attributes.put("email", email);
+			
+			// add any attributes configured by the env
+			config.getProfileAttributes().forEach(a -> {
+				attributes.put(a, jsonObject.optString(a));
+			});
+			
 			profile.setAttributes(attributes);
 
 			return profile;
@@ -127,7 +133,7 @@ public class OAuth2SecurityServiceSupplier implements ISecurityServiceSupplier {
 	@Override
 	public SpagoBIUserProfile checkAuthentication(String userId, String psw) {
 		OAuth2Client oauth2Client = new OAuth2Client();
-		return createUserProfile(oauth2Client.getAccessToken(userId, psw));
+		return createUserProfile(oauth2Client.getAccessTokenWithPassword(userId, psw));
 	}
 
 	@Override

--- a/knowageoauth2/src/main/java/it/eng/knowage/security/oauth2/OAuth2SecurityServiceSupplier.java
+++ b/knowageoauth2/src/main/java/it/eng/knowage/security/oauth2/OAuth2SecurityServiceSupplier.java
@@ -1,0 +1,152 @@
+/* SpagoBI, the Open Source Business Intelligence suite
+
+ * Copyright (C) 2012 Engineering Ingegneria Informatica S.p.A. - SpagoBI Competency Center
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0, without the "Incompatible With Secondary Licenses" notice.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package it.eng.knowage.security.oauth2;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.HttpStatus;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.log4j.LogMF;
+import org.apache.log4j.Logger;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import it.eng.spagobi.commons.SingletonConfig;
+import it.eng.spagobi.security.OAuth2.OAuth2Client;
+import it.eng.spagobi.security.OAuth2.OAuth2Config;
+import it.eng.spagobi.services.security.bo.SpagoBIUserProfile;
+import it.eng.spagobi.services.security.service.ISecurityServiceSupplier;
+import it.eng.spagobi.utilities.exceptions.SpagoBIRuntimeException;
+
+/**
+ * @author Alessandro Daniele (alessandro.daniele@eng.it)
+ * @author Jeremy Branham (jeremy@savantly.net)
+ *
+ */
+public class OAuth2SecurityServiceSupplier implements ISecurityServiceSupplier {
+	static private Logger logger = Logger.getLogger(OAuth2SecurityServiceSupplier.class);
+
+	@Override
+	public SpagoBIUserProfile createUserProfile(String userUniqueIdentifier) {
+		logger.debug("IN");
+
+		SpagoBIUserProfile profile;
+		try {
+			OAuth2Config config = OAuth2Config.getInstance();
+
+			OAuth2Client oauth2Client = new OAuth2Client();
+
+			HttpClient httpClient = oauth2Client.getHttpClient();
+
+			// We call the OAuth2 provider to get user's info
+			GetMethod httpget = new GetMethod(config.getUserInfoUrl());
+			httpget.addRequestHeader("Authorization", "Bearer " + userUniqueIdentifier);
+			int statusCode = httpClient.executeMethod(httpget);
+			byte[] response = httpget.getResponseBody();
+			if (statusCode != HttpStatus.SC_OK) {
+				logger.error("Error while getting user information from OAuth2 provider: server returned statusCode = "
+						+ statusCode);
+				LogMF.error(logger, "Server response is:\n{0}", new Object[] { new String(response) });
+				throw new SpagoBIRuntimeException(
+						"Error while getting user information from OAuth2 provider: server returned statusCode = "
+								+ statusCode);
+			}
+
+			String responseStr = new String(response);
+			LogMF.debug(logger, "Server response is:\n{0}", responseStr);
+			JSONObject jsonObject = new JSONObject(responseStr);
+
+			String userId = jsonObject.getString("sub");
+			logger.debug("User id is [" + userId + "]");
+			String userName = jsonObject.getString("preferred_username");
+			logger.debug("User name is [" + userName + "]");
+
+			profile = new SpagoBIUserProfile();
+			profile.setUniqueIdentifier(userUniqueIdentifier); // The OAuth2
+																// access token
+			profile.setUserId(userId);
+			profile.setUserName(userName);
+			profile.setOrganization("DEFAULT_TENANT");
+
+			/*
+			 * If the user's email is the same as the owner of the application (as
+			 * configured in the oauth2.config.properties file) we consider him as the
+			 * superadmin
+			 */
+			String adminEmail = config.getAdminEmail();
+			String email = jsonObject.getString("email");
+			profile.setIsSuperadmin(email.equalsIgnoreCase(adminEmail));
+
+			JSONArray jsonRolesArray = jsonObject.getJSONArray("roles");
+			List<String> roles = new ArrayList<String>();
+
+			// Read roles
+			String name;
+			for (int i = 0; i < jsonRolesArray.length(); i++) {
+				name = jsonRolesArray.getString(i);
+				if (Objects.nonNull(name))
+					roles.add(name.toLowerCase());
+			}
+
+			// If no roles were found, search for roles in the organizations
+			if (roles.size() == 0 && !jsonObject.isNull("organizations")) {
+				JSONArray organizations = jsonObject.getJSONArray("organizations");
+
+				// TODO: something?
+			}
+
+			if (roles.size() == 0) { // Add the default role
+				roles.add(SingletonConfig.getInstance().getConfigValue("SPAGOBI.SECURITY.DEFAULT_ROLE_ON_SIGNUP"));
+			}
+
+			String[] rolesString = new String[roles.size()];
+			profile.setRoles(roles.toArray(rolesString));
+
+			HashMap<String, String> attributes = new HashMap<String, String>();
+			attributes.put("userUniqueIdentifier", userUniqueIdentifier);
+			attributes.put("userId", userId);
+			attributes.put("userName", userName);
+			attributes.put("email", email);
+			profile.setAttributes(attributes);
+
+			return profile;
+		} catch (Exception e) {
+			throw new SpagoBIRuntimeException(
+					"Error while trying to read JSon object containing user profile's information from OAuth2 provider",
+					e);
+		} finally {
+			logger.debug("OUT");
+		}
+	}
+
+	@Override
+	public SpagoBIUserProfile checkAuthentication(String userId, String psw) {
+		OAuth2Client oauth2Client = new OAuth2Client();
+		return createUserProfile(oauth2Client.getAccessToken(userId, psw));
+	}
+
+	@Override
+	public SpagoBIUserProfile checkAuthenticationWithToken(String userId, String token) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public boolean checkAuthorization(String userId, String function) {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
+	public SpagoBIUserProfile checkAuthenticationToken(String token) {
+		return createUserProfile(token);
+	}
+
+}

--- a/knowageoauth2/src/main/java/it/eng/knowage/security/oauth2/OAuth2SecurityServiceSupplier.java
+++ b/knowageoauth2/src/main/java/it/eng/knowage/security/oauth2/OAuth2SecurityServiceSupplier.java
@@ -19,8 +19,6 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 
 import it.eng.spagobi.commons.SingletonConfig;
-import it.eng.spagobi.security.OAuth2.OAuth2Client;
-import it.eng.spagobi.security.OAuth2.OAuth2Config;
 import it.eng.spagobi.services.security.bo.SpagoBIUserProfile;
 import it.eng.spagobi.services.security.service.ISecurityServiceSupplier;
 import it.eng.spagobi.utilities.exceptions.SpagoBIRuntimeException;

--- a/knowageoauth2/src/main/java/it/eng/knowage/security/oauth2/OAuth2SecurityServiceSupplier.java
+++ b/knowageoauth2/src/main/java/it/eng/knowage/security/oauth2/OAuth2SecurityServiceSupplier.java
@@ -45,6 +45,9 @@ public class OAuth2SecurityServiceSupplier implements ISecurityServiceSupplier {
 
 			// We call the OAuth2 provider to get user's info
 			GetMethod httpget = new GetMethod(config.getUserInfoUrl());
+			
+			// TODO: This will fail if the access token is expired, and the UX does not reflect the actual cause.
+			// We should be using a refresh token I think.
 			httpget.addRequestHeader("Authorization", "Bearer " + userUniqueIdentifier);
 			int statusCode = httpClient.executeMethod(httpget);
 			byte[] response = httpget.getResponseBody();

--- a/knowageoauth2/src/main/java/it/eng/knowage/security/oauth2/OAuth2SecurityServiceSupplier.java
+++ b/knowageoauth2/src/main/java/it/eng/knowage/security/oauth2/OAuth2SecurityServiceSupplier.java
@@ -61,9 +61,9 @@ public class OAuth2SecurityServiceSupplier implements ISecurityServiceSupplier {
 			LogMF.debug(logger, "Server response is:\n{0}", responseStr);
 			JSONObject jsonObject = new JSONObject(responseStr);
 
-			String userId = jsonObject.getString("sub");
+			String userId = jsonObject.getString(config.getUserIdClaim());
 			logger.debug("User id is [" + userId + "]");
-			String userName = jsonObject.getString("preferred_username");
+			String userName = jsonObject.getString(config.getUserNameClaim());
 			logger.debug("User name is [" + userName + "]");
 
 			profile = new SpagoBIUserProfile();


### PR DESCRIPTION
I'm not sure of the guidelines on contributing, and the CLA link seems to be broke.  

If there's not already plans for a generic oauth2 solution, here's one I've tested with 7.4   

Also, made a few changes to the docker image to integrate better with kubernetes.   
There are examples on how to configure usage here -  
https://github.com/savantly-net/knowage-docker
  
The docker-compose file may not work because it's using a mock server, but I can confirm it's working well with keycloak.  
This PR may require changes, as I made some assumptions about namespaces and class names.  

