### PR TITLE
Remove duplicate log4j-web dependency

### DIFF
--- a/knowagewhatifengine/pom.xml
+++ b/knowagewhatifengine/pom.xml
@@ -220,12 +220,6 @@
 			<scope>test</scope>
 		</dependency>
 
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-web</artifactId>
-			<version>2.17.1</version>
-		</dependency>
-
 	</dependencies>
 
 	<name>knowagewhatifengine</name>


### PR DESCRIPTION
log4j-web dependency was declared twice leading to a Maven warning while building the project.