### PR TITLE
QBE - KNOWAGE-6844, KNOWAGE-7022

### DIFF
--- a/knowage-vue/src/components/functionalities/KnCalculatedField/KnCalculatedField.vue
+++ b/knowage-vue/src/components/functionalities/KnCalculatedField/KnCalculatedField.vue
@@ -33,7 +33,8 @@
                             ><template #option="slotProps">
                                 <div class="p-text-uppercase kn-list-item fieldType" draggable="true" @dragstart="dragElement($event, slotProps.option, 'field')">
                                     <div><i class="fa fa-solid fa-bars"></i></div>
-                                    <div class="p-ml-2">{{ slotProps.option.fieldAlias }}</div>
+                                    <div v-if="source === 'QBE'" class="p-ml-2">{{ slotProps.option.fieldLabel }}</div>
+                                    <div v-else class="p-ml-2">{{ slotProps.option.fieldAlias }}</div>
                                 </div>
                             </template></Listbox
                         >
@@ -107,7 +108,8 @@ export default defineComponent({
         readOnly: Boolean,
         descriptor: Object,
         template: {} as any,
-        valid: Boolean
+        valid: Boolean,
+        source: String
     },
     data() {
         return {
@@ -156,7 +158,7 @@ export default defineComponent({
             }
         }
 
-        if (!this.readOnly && this.template && !this.template.parameters) {
+        if (!this.readOnly && this.template && !this.template.parameters && this.source === 'QBE') {
             this.cf = { colName: this.template.alias, formula: this.template.expression } as IKnCalculatedField
         }
     },

--- a/knowage-vue/src/modules/qbe/QBE.vue
+++ b/knowage-vue/src/modules/qbe/QBE.vue
@@ -118,7 +118,7 @@
         <QBESavingDialog v-if="savingDialogVisible" :visible="savingDialogVisible" :propDataset="qbe" @close="savingDialogVisible = false" @datasetSaved="$emit('datasetSaved')" />
         <QBEJoinDefinitionDialog v-if="joinDefinitionDialogVisible" :visible="joinDefinitionDialogVisible" :qbe="qbe" :propEntities="entities?.entities" :id="uniqueID" :selectedQuery="selectedQuery" @close="onJoinDefinitionDialogClose"></QBEJoinDefinitionDialog>
 
-        <KnCalculatedField v-model:template="selectedCalcField" v-model:visibility="calcFieldDialogVisible" :fields="calcFieldColumns" :descriptor="calcFieldDescriptor" :readOnly="false" :valid="true" @save="onCalcFieldSave" @cancel="calcFieldDialogVisible = false">
+        <KnCalculatedField v-model:template="selectedCalcField" v-model:visibility="calcFieldDialogVisible" :fields="calcFieldColumns" :descriptor="calcFieldDescriptor" :readOnly="false" :valid="true" source="QBE" @save="onCalcFieldSave" @cancel="calcFieldDialogVisible = false">
             <template #additionalInputs>
                 <div class="p-field" :class="[selectedCalcField.type === 'DATE' ? 'p-col-3' : 'p-col-4']">
                     <span class="p-float-label ">
@@ -503,7 +503,7 @@ export default defineComponent({
                 { key: '1', label: this.$t('qbe.detailView.toolbarMenu.sql'), command: () => this.showSQLQuery() },
                 { key: '2', icon: repetitionIcon, label: this.$t('qbe.detailView.toolbarMenu.repetitions'), command: () => this.toggleDiscardRepetitions() },
                 { key: '3', label: this.$t('common.parameters'), command: () => this.showParamDialog() },
-                { key: '4', label: this.$t('components.knCalculatedField.title'), visible: !this.smartView, command: () => this.addCalcField() },
+                { key: '4', label: this.$t('components.knCalculatedField.title'), visible: !this.smartView && this.selectedQuery.fields.length > 0, command: () => this.addCalcField() },
                 { key: '5', label: this.$t('qbe.advancedFilters.advancedFilterVisualisation'), command: () => this.showAdvancedFilters() },
                 { key: '6', label: this.$t('qbe.joinDefinitions.title'), command: () => this.showJoinDefinitions() },
                 {
@@ -782,7 +782,7 @@ export default defineComponent({
         createCalcFieldColumns() {
             this.calcFieldColumns = []
             this.selectedQuery.fields.forEach((field) => {
-                field.type != 'inline.calculated.field' ? this.calcFieldColumns.push({ fieldAlias: field.alias }) : ''
+                field.type != 'inline.calculated.field' ? this.calcFieldColumns.push({ fieldAlias: `$F{${field.alias}}`, fieldLabel: field.alias }) : ''
             })
         },
         editCalcField(calcField, index) {

--- a/knowage-vue/src/modules/qbe/QBE.vue
+++ b/knowage-vue/src/modules/qbe/QBE.vue
@@ -129,6 +129,9 @@
                 <div v-if="selectedCalcField.type === 'DATE'" class="p-field p-col-3">
                     <span class="p-float-label ">
                         <Dropdown id="type" class="kn-material-input" v-model="selectedCalcField.format" :options="qbeDescriptor.admissibleDateFormats">
+                            <template #value>
+                                <span>{{ selectedCalcField.format ? moment().format(selectedCalcField.format) : '' }}</span>
+                            </template>
                             <template #option="slotProps">
                                 <span>{{ moment().format(slotProps.option) }}</span>
                             </template>

--- a/knowage-vue/src/modules/qbe/QBECalcFieldDescriptor.json
+++ b/knowage-vue/src/modules/qbe/QBECalcFieldDescriptor.json
@@ -76,6 +76,195 @@
             "help": "dataPreparation.substring",
             "label": "substring",
             "name": "substring"
+        },
+        {
+            "category": "SQL",
+            "formula": "CASE WHEN expr1 THEN expr2 [WHEN expr3 THEN expr4]* [ELSE expr5] END",
+            "help": "dataPreparation.case",
+            "label": "case",
+            "name": "case"
+        },
+        {
+            "category": "TIME",
+            "formula": "current_date",
+            "help": "dataPreparation.current_date",
+            "label": "CURRENT_DATE",
+            "name": "CURRENT_DATE"
+        },
+        {
+            "category": "TIME",
+            "formula": "current_time",
+            "help": "dataPreparation.current_time",
+            "label": "CURRENT_TIME",
+            "name": "CURRENT_TIME"
+        },
+        {
+            "category": "TIME",
+            "formula": "second(datetime_expression)",
+            "help": "dataPreparation.second",
+            "label": "second",
+            "name": "second"
+        },
+        {
+            "category": "TIME",
+            "formula": "hour(datetime_expression)",
+            "help": "dataPreparation.hour",
+            "label": "hour",
+            "name": "hour"
+        },
+        {
+            "category": "TIME",
+            "formula": "year(date_expression)",
+            "help": "dataPreparation.year",
+            "label": "year",
+            "name": "year"
+        },
+        {
+            "category": "TIME",
+            "formula": "month(date_expression)",
+            "help": "dataPreparation.month",
+            "label": "month",
+            "name": "month"
+        },
+        {
+            "category": "TIME",
+            "formula": "day(date_expression)",
+            "help": "dataPreparation.day",
+            "label": "day",
+            "name": "day"
+        },
+        {
+            "category": "TIME",
+            "formula": "get_quarter(date_expression)",
+            "help": "dataPreparation.get_quarter",
+            "label": "get_quarter",
+            "name": "get_quarter"
+        },
+        {
+            "category": "TIME",
+            "formula": "get_week(date_expression)",
+            "help": "dataPreparation.get_week",
+            "label": "get_week",
+            "name": "get_week"
+        },
+        {
+            "category": "TIME",
+            "formula": "get_day_of_the_week(date_expression)",
+            "help": "dataPreparation.get_day_of_the_week",
+            "label": "get_day_of_the_week",
+            "name": "get_day_of_the_week"
+        },
+        {
+            "category": "TIME",
+            "formula": "add_days(${date_expression},${number_of_days})",
+            "help": "dataPreparation.add_days",
+            "label": "add_days",
+            "name": "add_days"
+        },
+        {
+            "category": "TIME",
+            "formula": "add_hours(${date_expression},${number_of_hours})",
+            "help": "dataPreparation.add_hours",
+            "label": "add_hours",
+            "name": "add_hours"
+        },
+        {
+            "category": "TIME",
+            "formula": "add_months(${date_expression},${number_of_months})",
+            "help": "dataPreparation.add_months",
+            "label": "add_months",
+            "name": "add_months"
+        },
+        {
+            "category": "TIME",
+            "formula": "add_years(${date_expression},${number_of_years})",
+            "help": "dataPreparation.add_years",
+            "label": "add_years",
+            "name": "add_years"
+        },
+        {
+            "category": "TIME",
+            "formula": "subtract_days(${date_expression},${number_of_days})",
+            "help": "dataPreparation.subtract_days",
+            "label": "subtract_days",
+            "name": "subtract_days"
+        },
+        {
+            "category": "TIME",
+            "formula": "subtract_hours(${date_expression},${number_of_hours})",
+            "help": "dataPreparation.subtract_hours",
+            "label": "subtract_hours",
+            "name": "subtract_hours"
+        },
+        {
+            "category": "TIME",
+            "formula": "subtract_months(${date_expression},${number_of_months})",
+            "help": "dataPreparation.subtract_months",
+            "label": "subtract_months",
+            "name": "subtract_months"
+        },
+        {
+            "category": "TIME",
+            "formula": "subtract_years(${date_expression},${number_of_years})",
+            "help": "dataPreparation.subtract_years",
+            "label": "subtract_years",
+            "name": "subtract_years"
+        },
+        {
+            "category": "TIME",
+            "formula": "datediff_in_days(${starting_date},${ending_date})",
+            "help": "dataPreparation.datediff_in_days",
+            "label": "datediff_in_days",
+            "name": "datediff_in_days"
+        },
+        {
+            "category": "TIME",
+            "formula": "datediff_in_hours(${starting_date},${ending_date})",
+            "help": "dataPreparation.datediff_in_hours",
+            "label": "datediff_in_hours",
+            "name": "datediff_in_hours"
+        },
+        {
+            "category": "TIME",
+            "formula": "datediff_in_minutes(${starting_date},${ending_date})  ",
+            "help": "dataPreparation.datediff_in_minutes",
+            "label": "datediff_in_minutes",
+            "name": "datediff_in_minutes"
+        },
+        {
+            "category": "SPATIAL",
+            "formula": "distance(${geom1}, ${geom2}, ${tol}, ${unit})",
+            "help": "dataPreparation.distance",
+            "label": "distance",
+            "name": "distance"
+        },
+        {
+            "category": "SPATIAL",
+            "formula": "centroid(${geom1}, ${tol})",
+            "help": "dataPreparation.centroid",
+            "label": "Centroid",
+            "name": "Centroid"
+        },
+        {
+            "category": "SPATIAL",
+            "formula": "length_spa(${geom}, ${tol}, ${unit})",
+            "help": "dataPreparation.length_spa",
+            "label": "length_spa",
+            "name": "length_spa"
+        },
+        {
+            "category": "SPATIAL",
+            "formula": "relate(${geom1}, ${mask}, ${geom2}, ${tol}))",
+            "help": "dataPreparation.relate",
+            "label": "Relate",
+            "name": "Relate"
+        },
+        {
+            "category": "SPATIAL",
+            "formula": "intersection(${geom1},  ${geom2}, ${tol}))",
+            "help": "dataPreparation.intersection",
+            "label": "Intersection",
+            "name": "Intersection"
         }
     ],
     "availableOutputTypes": [

--- a/knowage-vue/src/modules/qbe/qbeDialogs/qbeSavingDialog/QBESavingDialog.vue
+++ b/knowage-vue/src/modules/qbe/qbeDialogs/qbeSavingDialog/QBESavingDialog.vue
@@ -112,9 +112,9 @@ export default defineComponent({
                 })
                 .then((response: AxiosResponse<any>) => {
                     this.$store.commit('setInfo', { title: this.$t('common.toast.createTitle'), msg: this.$t('common.toast.success') })
+                    this.selectedDataset.meta = response.data.meta
                     if (!this.selectedDataset.id) {
                         this.selectedDataset.id = response.data.id
-                        this.selectedDataset.meta = response.data.meta
                         this.$emit('created', response)
                     } else this.$emit('updated')
                     this.$emit('datasetSaved')

--- a/knowage-vue/src/modules/qbe/qbeTables/qbeSmartTable/QBESmartTable.vue
+++ b/knowage-vue/src/modules/qbe/qbeTables/qbeSmartTable/QBESmartTable.vue
@@ -50,8 +50,9 @@
             </template>
             <template #body="slotProps">
                 <span v-if="typeof slotProps.data[`column_${index + 1}`] === 'number' && slotProps.data[`column_${index + 1}`]"> {{ getFormattedNumber(slotProps.data[`column_${index + 1}`]) }}</span>
-                <span v-else-if="previewData?.metaData?.fields[index + 1]?.type === 'date'">{{ getFormattedDate(slotProps.data[`column_${index + 1}`], previewData.metaData.fields[index + 1].metawebDateFormat, 'DD/MM/YYYY') }} </span>
-                <span v-else-if="previewData?.metaData?.fields[index + 1]?.type === 'timestamp'">{{ getFormattedDate(slotProps.data[`column_${index + 1}`], previewData.metaData.fields[index + 1].metawebDateFormat, 'DD/MM/YYYY HH:mm:ss.SSS') }} </span>
+                <span v-if="previewData?.metaData?.fields[index + 1]?.type === 'date' && col.type != 'inline.calculated.field'">{{ getFormattedDate(slotProps.data[`column_${index + 1}`], previewData.metaData.fields[index + 1].metawebDateFormat, 'DD/MM/YYYY') }} </span>
+                <span v-else-if="previewData?.metaData?.fields[index + 1]?.type === 'timestamp' && col.type != 'inline.calculated.field'">{{ getFormattedDate(slotProps.data[`column_${index + 1}`], previewData.metaData.fields[index + 1].metawebDateFormat, 'DD/MM/YYYY HH:mm:ss.SSS') }} </span>
+                <span v-else-if="previewData?.metaData?.fields[index + 1]?.type === 'timestamp' && col.type == 'inline.calculated.field'">{{ getFormattedDate(slotProps.data[`column_${index + 1}`], col.id.format, 'DD/MM/YYYY HH:mm:ss.SSS') }} </span>
                 <span v-else v-tooltip.bottom="slotProps.data[`column_${index + 1}`]">{{ slotProps.data[`column_${index + 1}`] }}</span>
             </template>
         </Column>


### PR DESCRIPTION
[KNOWAGE-6844](https://production.eng.it/jira/browse/KNOWAGE-6844)
Reloading metadata each time a dataset is saved, should fix the issue.

[KNOWAGE-7022](https://production.eng.it/jira/browse/KNOWAGE-7022)
Showing proper formats inside the dropdown.
If the column is calculated field, smart table no longer takes the format from the response, but from the field object itself, because BE returns un-formatted date.
KnCalculatedField, has a property that serves as a check to see if its being loaded from QBE, if it is, it will just display another property of the object, nothing major has changed inside the component.
