### PR TITLE
Configure resources plugin to avoid filtering xlsm file

### DIFF
--- a/knowage/pom.xml
+++ b/knowage/pom.xml
@@ -120,6 +120,15 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<artifactId>maven-resources-plugin</artifactId>
+				<version>2.7</version>
+				<configuration>
+					<nonFilteredFileExtensions>
+						<nonFilteredFileExtension>xlsm</nonFilteredFileExtension>
+					</nonFilteredFileExtensions>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
Currently filtering is done on all resources. Doing so on a file such `knowage/src/main/resources/it/eng/spagobi/tools/dataset/service/export_dataset_template.xlsm` lead to error during the build. This change configure the resources plugin to skip files with *.xlsm (Office Open XML format used by Excel).

I have read the CLA Document and I hereby sign the CLA