### PR TITLE
Fix Zip Slip 

### DIFF
--- a/knowage-api/src/main/java/it/eng/knowage/resourcemanager/service/impl/ResourceManagerAPIImpl.java
+++ b/knowage-api/src/main/java/it/eng/knowage/resourcemanager/service/impl/ResourceManagerAPIImpl.java
@@ -546,6 +546,10 @@ public class ResourceManagerAPIImpl implements ResourceManagerAPI {
 			String newPath = extractFolder;
 
 			new File(newPath).mkdir();
+
+      // Get canonical path for security validation
+      String extractDirCanonicalPath = extractDir.getCanonicalPath();
+
 			Enumeration<? extends ZipEntry> zipFileEntries = zip.entries();
 
 			// Process each entry
@@ -555,6 +559,14 @@ public class ResourceManagerAPIImpl implements ResourceManagerAPI {
 				String currentEntry = entry.getName();
 
 				File destFile = new File(newPath, currentEntry);
+
+        // Security check: Prevent Zip Slip vulnerability
+            String destFileCanonicalPath = destFile.getCanonicalPath();
+            if (!destFileCanonicalPath.startsWith(extractDirCanonicalPath + File.separator) && 
+                !destFileCanonicalPath.equals(extractDirCanonicalPath)) {
+                throw new IOException("Entry is outside of the target dir: " + currentEntry);
+            }
+            
 				File destinationParent = destFile.getParentFile();
 
 				// create the parent directory structure if needed

--- a/knowageutils/src/main/java/it/eng/spagobi/commons/utilities/ZipUtils.java
+++ b/knowageutils/src/main/java/it/eng/spagobi/commons/utilities/ZipUtils.java
@@ -242,6 +242,12 @@ public class ZipUtils {
 				if (entry.isDirectory()) {
 
 					Path path = Paths.get(outFolder.getPath(), entry.getName());
+
+          // Security check: Prevent Zip Slip attack
+          if (!path.normalize().startsWith(outFolder.toPath().normalize())) {
+              throw new IOException("Entry is outside of the target dir: " + entry.getName());
+          }
+
 					Files.createDirectories(path);
 
 				} else {
@@ -252,8 +258,16 @@ public class ZipUtils {
 					Path path = Paths.get(outFolder.getPath(),
 							(prependZipFileName ? zipFileName + "_" : "") + entry.getName());
 
+          // Security check: Prevent Zip Slip attack
+          if (!path.normalize().startsWith(outFolder.toPath().normalize())) {
+              throw new IOException("Entry is outside of the target dir: " + entry.getName());
+          }
+
 					if (Files.exists(path))
 						throw new ZipException("File already exists: " + path);
+
+          // Ensure parent directories exist
+          Files.createDirectories(path.getParent());
 
 					// write the files to the disk
 					try (OutputStream os = Files.newOutputStream(path);


### PR DESCRIPTION
Prevents Zip Slip attacks that could allow attackers to overwrite arbitrary files on the filesystem, potentially leading to code execution or system compromise.