### PR TITLE
Use platform newlines in script engine output

### DIFF
--- a/knowageutils/src/main/java/it/eng/spagobi/utilities/scripting/SpagoBIScriptManager.java
+++ b/knowageutils/src/main/java/it/eng/spagobi/utilities/scripting/SpagoBIScriptManager.java
@@ -283,12 +283,12 @@ public class SpagoBIScriptManager {
 			String engVersion = factory.getEngineVersion();
 			String langName = factory.getLanguageName();
 			String langVersion = factory.getLanguageVersion();
-			System.out.printf("\tScript Engine: %s (%s)\n", engName, engVersion);
+			System.out.printf("\tScript Engine: %s (%s)%n", engName, engVersion);
 			List<String> engNames = factory.getNames();
 			for (String name : engNames) {
-				System.out.printf("\tEngine Alias: %s\n", name);
+				System.out.printf("\tEngine Alias: %s%n", name);
 			}
-			System.out.printf("\tLanguage: %s (%s)\n", langName, langVersion);
+			System.out.printf("\tLanguage: %s (%s)%n", langName, langVersion);
 		}
 	}
 }


### PR DESCRIPTION
Use printf's %n conversion in SpagoBIScriptManager.printInfo instead of hard-coded newline characters. This keeps the diagnostic output native on Windows while preserving the existing output on Unix-like systems.

Testing:
- git diff --check
- Formatting-only output change; no production logic changed.